### PR TITLE
additionally activate extension when files are saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to the "shebang-language-associator" extension will be documented in this file.
 
+## [1.3.0]
+- The extension is activated upon saving files. In previous versions, the extension was only activated upon installation and when opening files.
+
 ## [1.2.0]
 - Add support for zsh and scripts run by the default shell (such as golang scripts).
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "shebang-language-associator",
   "displayName": "Shebang Language Associator",
   "description": "A tiny extension to associate shebang lines with languages",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "publisher": "davidhewitt",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "shebang-language-associator",
   "displayName": "Shebang Language Associator",
   "description": "A tiny extension to associate shebang lines with languages",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "publisher": "davidhewitt",
   "license": "MIT",
   "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,11 @@ export function activate(context: vscode.ExtensionContext) {
      */
     disposable = vscode.workspace.onDidOpenTextDocument(checkFile);
     context.subscriptions.push(disposable);
+    /*
+     * And also when files are saved.
+     */
+    disposable = vscode.workspace.onDidSaveTextDocument(checkFile);
+    context.subscriptions.push(disposable);
 }
 
 /**


### PR DESCRIPTION
Tested locally with process described at https://code.visualstudio.com/api/get-started/your-first-extension:

The extension compiles just fine, opens `[Extension Development Host]` in a new window, and I observe syntax highlighting works on file save. 